### PR TITLE
Use node-name and logger-category from wf-cekit-modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -85,7 +85,9 @@ modules:
           - name: jboss.container.wildfly.launch.datasources
           - name: jboss.container.wildfly.launch.json-logging
           - name: jboss.container.wildfly.launch.jgroups
+          - name: jboss.container.wildfly.launch.logger-category
           - name: jboss.container.wildfly.launch.mp-config
+          - name: jboss.container.wildfly.launch.os.node-name
           - name: jboss.container.wildfly.launch.tracing
           - name: jboss.container.wildfly.launch.deployment-scanner
           # New wildfly-cekit-modules - END


### PR DESCRIPTION
These are now in wildfly-cekit-modules