### PR TITLE
Add jboss.container.wildfly.launch.https to image.yaml

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -92,6 +92,7 @@ modules:
           - name: jboss.container.wildfly.launch.tracing
           - name: jboss.container.wildfly.launch.deployment-scanner
           - name: jboss.container.wildfly.launch.keycloak
+          - name: jboss.container.wildfly.launch.https
           # New wildfly-cekit-modules - END
           # These are moved to wf-cekit
           # - name: jboss.eap.cd.logging


### PR DESCRIPTION
Add a module for https legacy configuration

Requires: wildfly/wildfly-cekit-modules#26