### PR TITLE
 Use access-log-valve.sh from wildfly-cekit-modules

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -82,6 +82,7 @@ modules:
           #  version: "1.0"
           # New wildfly-cekit-modules
           - name: jboss.container.wildfly.launch.admin
+          - name: jboss.container.wildfly.launch.access-log-valve
           - name: jboss.container.wildfly.launch-config.config
           - name: jboss.container.wildfly.launch-config.os
           - name: jboss.container.wildfly.launch.datasources


### PR DESCRIPTION
This is a trio of three pull requests. These are:

* https://github.com/wildfly/wildfly-cekit-modules/pull/48
* https://github.com/wildfly/temp-eap-modules/pull/34
* https://github.com/wildfly/temp-openshift-image/pull/21